### PR TITLE
feat: 인벤토리 페이지 생성 및 레이아웃 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,15 @@
 import { Route, Routes } from "react-router-dom";
 import Home from "./page/home/Home";
+import Inventory from "./page/inventory/Inventory";
+import Layout from "./components/layout/Layout";
 
 function App() {
   return (
     <Routes>
-      <Route path="/" element={<Home />} />
+      <Route path="/" element={<Layout />}>
+        <Route index element={<Home />} />
+        <Route path="/inventory" element={<Inventory />} />
+      </Route>
     </Routes>
   );
 }

--- a/src/components/Inventory/InventoryContainer.tsx
+++ b/src/components/Inventory/InventoryContainer.tsx
@@ -1,0 +1,15 @@
+import InventoryItem from "./InventoryItem";
+import InventoryList from "./InventoryList";
+import ShopItem from "./ShopItem";
+
+const InventoryContainer = () => {
+  return (
+    <div className="px-2 py-2 w-[724px] h-[calc(100vh-112px)] border rounded-xl bg-gray-100 flex flex-col">
+      <InventoryList />
+      <InventoryItem />
+      <ShopItem />
+    </div>
+  );
+};
+
+export default InventoryContainer;

--- a/src/components/Inventory/InventoryItem.tsx
+++ b/src/components/Inventory/InventoryItem.tsx
@@ -1,0 +1,5 @@
+const InventoryItem = () => {
+  return <div>InventoryItem</div>;
+};
+
+export default InventoryItem;

--- a/src/components/Inventory/InventoryList.tsx
+++ b/src/components/Inventory/InventoryList.tsx
@@ -1,0 +1,5 @@
+const InventoryList = () => {
+  return <div>InventoryList</div>;
+};
+
+export default InventoryList;

--- a/src/components/Inventory/ShopItem.tsx
+++ b/src/components/Inventory/ShopItem.tsx
@@ -1,0 +1,5 @@
+const ShopItem = () => {
+  return <div>ShopItem</div>;
+};
+
+export default ShopItem;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { Logo } from "../config/IconData";
+import { Logo } from "../../config/IconData";
 import { MdDateRange, MdSearch } from "react-icons/md";
 import { TbBell } from "react-icons/tb";
 import { FiUser } from "react-icons/fi";

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,0 +1,15 @@
+import { Outlet } from "react-router-dom";
+import Header from "./Header";
+
+const Layout = () => {
+  return (
+    <>
+      <Header />
+      <div className="flex my-4 gap-4 justify-center min-w-[1900px] font-default">
+        <Outlet />
+      </div>
+    </>
+  );
+};
+
+export default Layout;

--- a/src/components/profile/ProfileImage.tsx
+++ b/src/components/profile/ProfileImage.tsx
@@ -1,11 +1,17 @@
+import { useNavigate } from "react-router-dom";
 import { Shirt } from "../../config/IconData";
 
 const ProfileImage = () => {
+  const navigate = useNavigate();
+
   return (
     <div className="relative w-[314px] h-[314px] rounded-xl border border-gray-100">
       <div className="flex justify-between">
         <div>
-          <button className="absolute right-0 group w-[42px] h-[50px] bg-gray-100 hover:bg-gray-200 rounded-lg m-2 flex flex-col justify-center items-center">
+          <button
+            className="absolute right-0 group w-[42px] h-[50px] bg-gray-100 hover:bg-gray-200 rounded-lg m-2 flex flex-col justify-center items-center"
+            onClick={() => navigate("/inventory")}
+          >
             <Shirt className="fill-gray-400 group-hover:fill-black" />
             <p className="text-[10px] text-gray-400 group-hover:text-black">꾸미기</p>
           </button>

--- a/src/components/profilePreview/FreeSetBtn.tsx
+++ b/src/components/profilePreview/FreeSetBtn.tsx
@@ -1,0 +1,5 @@
+const FreeSetBtn = () => {
+  return <div>FreeSetBtn</div>;
+};
+
+export default FreeSetBtn;

--- a/src/components/profilePreview/ProfilePreviewImg.tsx
+++ b/src/components/profilePreview/ProfilePreviewImg.tsx
@@ -1,0 +1,5 @@
+const ProfilePreviewImg = () => {
+  return <div>ProfilePreviewImg</div>;
+};
+
+export default ProfilePreviewImg;

--- a/src/components/profilePreview/SaveBtn.tsx
+++ b/src/components/profilePreview/SaveBtn.tsx
@@ -1,0 +1,5 @@
+const SaveBtn = () => {
+  return <div>SaveBtn</div>;
+};
+
+export default SaveBtn;

--- a/src/components/profilePreview/TabBtn.tsx
+++ b/src/components/profilePreview/TabBtn.tsx
@@ -1,0 +1,5 @@
+const TabBtn = () => {
+  return <div>TabBtn</div>;
+};
+
+export default TabBtn;

--- a/src/page/home/Home.tsx
+++ b/src/page/home/Home.tsx
@@ -1,16 +1,12 @@
-import Header from "../../components/Header";
 import Profile from "./Profile";
 import Main from "./Main";
 import Sidebar from "./Sidebar";
 const Home = () => {
   return (
     <>
-      <Header />
-      <div className="flex my-4 gap-4 justify-center min-w-[1900px] font-default">
-        <Profile />
-        <Main />
-        <Sidebar />
-      </div>
+      <Profile />
+      <Main />
+      <Sidebar />
     </>
   );
 };

--- a/src/page/inventory/Inventory.tsx
+++ b/src/page/inventory/Inventory.tsx
@@ -1,0 +1,15 @@
+import InventoryContainer from "../../components/Inventory/InventoryContainer";
+import Sidebar from "../home/Sidebar";
+import ProfilePreview from "./ProfilePreview";
+
+const Inventory = () => {
+  return (
+    <>
+      <ProfilePreview />
+      <InventoryContainer />
+      <Sidebar />
+    </>
+  );
+};
+
+export default Inventory;

--- a/src/page/inventory/ProfilePreview.tsx
+++ b/src/page/inventory/ProfilePreview.tsx
@@ -1,0 +1,17 @@
+import TabBtn from "../../components/profilePreview/TabBtn";
+import FreeSetBtn from "../../components/profilePreview/FreeSetBtn";
+import ProfilePreviewImg from "../../components/profilePreview/ProfilePreviewImg";
+import SaveBtn from "../../components/profilePreview/SaveBtn";
+
+const ProfilePreview = () => {
+  return (
+    <div className="w-[354px] h-[500px] border rounded-xl flex flex-col p-5">
+      <TabBtn />
+      <FreeSetBtn />
+      <ProfilePreviewImg />
+      <SaveBtn />
+    </div>
+  );
+};
+
+export default ProfilePreview;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #4 

## 📝작업 내용

> 인벤토리 페이지 생성했습니다. 
홈페이지와 프로필 & main UI가 달라서 페이지 라우트 새로 생성했어요.
헤더 컴포넌트가 공통으로 쓰여서 레이아웃으로 생성하느라 코드가 좀 수정됐습니다.

### 스크린샷 (선택)

<img width="835" alt="스크린샷 2024-12-12 오후 5 51 25" src="https://github.com/user-attachments/assets/7370921a-ef57-4d3f-9209-3fcc04039984" />

<img width="610" alt="스크린샷 2024-12-12 오후 5 51 41" src="https://github.com/user-attachments/assets/9fb6bfee-c218-4123-9445-415b2478a5aa" />

## 💬리뷰 요구사항(선택)

1. `App` 컴포넌트 수정 
2. `Layout` 컴포넌트 생성 

모두 pull 받으신 다음에 작업 부탁드릴게요~!